### PR TITLE
Added a deep merger, able to merge collections and beyond.

### DIFF
--- a/NConfig.Tests/DeepMergeConfigs/Test1.config
+++ b/NConfig.Tests/DeepMergeConfigs/Test1.config
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="mergeTest" type="NConfig.Tests.DeepMergerTestSection, NConfig.Tests"/>
+  </configSections>
+
+  <!-- Overrides all -->
+  
+  <mergeTest>
+    <OverriddenProperty value="override2" />
+    <!-- JumpOverProperty not existing -->
+    <NewEmptyProperty value="" />
+    <NewNullProperty name="testName" /> <!-- no value -->
+
+    <ClearCollection>
+      <clear />
+      <ele name="test1" value="test" />
+      <ele name="test2" />
+      <ele name="test4" value="test" />
+    </ClearCollection>
+
+    <RemoveCollection>
+      <remove name="removeSame" />
+      <ele name="removeSame" value="test" />
+      <remove name="fullRemove" />
+      <ele name="removedLower" value="test" />
+      <ele name="removedLowerWithSpace" value="test" />
+    </RemoveCollection>
+
+    <SubCollection>
+      <main name="test1">
+        <values>
+          <sub name="t1" value="test" />
+          <sub name="t2" value="override" />
+          <remove name="removed" />
+        </values>
+      </main>
+      <main name="test2">
+        <values>
+          <sub name="t1" value="test2" />
+          <remove name="t2" />
+        </values>
+      </main>
+    </SubCollection>
+  </mergeTest>
+</configuration>

--- a/NConfig.Tests/DeepMergeConfigs/Test2.config
+++ b/NConfig.Tests/DeepMergeConfigs/Test2.config
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="mergeTest" type="NConfig.Tests.DeepMergerTestSection, NConfig.Tests"/>
+  </configSections>
+
+  <!-- Overrides all -->
+
+  <mergeTest>
+    <OverriddenProperty value="override1" />
+    <JumpOverProperty value="override" />
+    <NewEmptyProperty value="test" />
+    <NewNullProperty name="testName" value="test" />
+    
+    <ClearCollection>
+      <ele name="test1" value="overrided" />
+      <ele name="test2" value="overrided" />
+      <ele name="test3" value="overrided" />
+      <remove name="test4" />
+    </ClearCollection>
+
+    <RemoveCollection>
+      <ele name="removeSame" value="overrided" />
+      <ele name="fullRemove" value="removed" />
+      <remove name="fullRemoveLower" />
+      <remove name="removedLower" />
+    </RemoveCollection>
+
+    <SubCollection>
+      <main name="test1">
+        <values>
+          <sub name="t2" value="test" />
+          <sub name="removed" value="test" />
+          <sub name="t3" value="test" />
+        </values>
+      </main>
+      <main name="test2">
+        <values>
+          <sub name="t1" value="test3" />
+        </values>
+      </main>
+      <main name="test3">
+        <values>
+          <sub name="t1" value="test4" />
+        </values>
+      </main>
+    </SubCollection>
+  </mergeTest>
+</configuration>

--- a/NConfig.Tests/DeepMergeConfigs/Test3.config
+++ b/NConfig.Tests/DeepMergeConfigs/Test3.config
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="mergeTest" type="NConfig.Tests.DeepMergerTestSection, NConfig.Tests"/>
+  </configSections>
+
+  <!-- Overrides all -->
+
+  <mergeTest>
+    <JumpOverProperty value="test" />
+    
+    <ClearCollection>
+      <ele name="test1" />
+      <ele name="test2" />
+    </ClearCollection>
+
+    <RemoveCollection>
+      <ele name="removeSame" value="overrided" />
+      <ele name="fullRemove" value="removed" />
+      <ele name="fullRemoveLower" value="removed" />
+      <ele name="removedLower" value="removed" />
+      <remove name="removedLowerWithSpace" />
+    </RemoveCollection>
+  </mergeTest>
+</configuration>

--- a/NConfig.Tests/DeepMergeConfigs/Test4.config
+++ b/NConfig.Tests/DeepMergeConfigs/Test4.config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="mergeTest" type="NConfig.Tests.DeepMergerTestSection, NConfig.Tests"/>
+  </configSections>
+
+  <!-- Overrides all -->
+
+  <mergeTest>
+    <OverriddenProperty value="test" />
+    
+    <ClearCollection>
+      <ele name="test1" />
+      <ele name="test2" />
+    </ClearCollection>
+  </mergeTest>
+</configuration>

--- a/NConfig.Tests/DeepMergerTests.cs
+++ b/NConfig.Tests/DeepMergerTests.cs
@@ -1,0 +1,281 @@
+﻿using System.Collections.Generic;
+using System.Configuration;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NConfig.Tests {
+    [TestFixture]
+    public class DeepMergerTests {
+        private const string FOLDER = "DeepMergeConfigs\\";
+        private const string CONFIG_1 = FOLDER + "Test1.config";
+        private const string CONFIG_2 = FOLDER + "Test2.config";
+        private const string CONFIG_3 = FOLDER + "Test3.config";
+        private const string CONFIG_4 = FOLDER + "Test4.config";
+
+        #region GetMergedConfig
+        private IEnumerable<FileInfo> GetFiles() {
+            yield return new FileInfo(CONFIG_1);
+            yield return new FileInfo(CONFIG_2);
+            yield return new FileInfo(CONFIG_3);
+            yield return new FileInfo(CONFIG_4);
+        }
+
+        private DeepMergerTestSection GetMergedConfig() {
+            var merger = new DeepMerger<DeepMergerTestSection>();
+            NConfigurator.RegisterSectionMerger(merger);
+
+            IEnumerable<FileInfo> files = GetFiles();
+            string[] configFileNames = files
+                    .Select(x => x.FullName)
+                    .ToArray();
+            return NConfigurator
+                    .UsingFiles(configFileNames)
+                    .GetSection<DeepMergerTestSection>("mergeTest");
+        }
+        #endregion
+
+        [Test]
+        public void DeepMerger_MergeProperties() {
+            DeepMergerTestSection testSection = GetMergedConfig();
+
+            Assert.IsNotNull(testSection);
+            Assert.AreEqual("override2", testSection.OverriddenProperty.Value);
+            Assert.AreEqual("override", testSection.JumpOverProperty.Value);
+            Assert.AreEqual("", testSection.NewEmptyProperty.Value);
+            Assert.AreEqual("test", testSection.NewNullProperty.Value);
+        }
+
+        [Test]
+        public void DeepMerger_MergeCollections_ClearCollection() {
+            DeepMergerTestSection testSection = GetMergedConfig();
+            
+            var coll = testSection?.ClearCollection;
+            var test1 = coll?.FirstOrDefault(x => x.Name == "test1");
+            var test2 = coll?.FirstOrDefault(x => x.Name == "test2");
+            var test3 = coll?.FirstOrDefault(x => x.Name == "test3");
+            var test4 = coll?.FirstOrDefault(x => x.Name == "test4");
+
+            Assert.IsNotNull(testSection);
+            Assert.IsNotNull(coll);
+            Assert.AreEqual(3, coll.Count);
+            
+            Assert.IsNotNull(test1);
+            Assert.AreEqual("test", test1.Value);
+
+            Assert.IsNotNull(test2);
+            Assert.AreEqual("", test2.Value); // interestingly not null
+
+            Assert.IsNull(test3);
+
+            Assert.IsNotNull(test4);
+            Assert.AreEqual("test", test4.Value);
+        }
+
+        [Test]
+        public void DeepMerger_MergeCollections_RemoveCollection() {
+            DeepMergerTestSection testSection = GetMergedConfig();
+
+            var coll = testSection?.RemoveCollection;
+            var test1 = coll?.FirstOrDefault(x => x.Name == "removeSame");
+            var test2 = coll?.FirstOrDefault(x => x.Name == "fullRemove");
+            var test3 = coll?.FirstOrDefault(x => x.Name == "fullRemoveLower");
+            var test4 = coll?.FirstOrDefault(x => x.Name == "removedLower");
+            var test5 = coll?.FirstOrDefault(x => x.Name == "removedLowerWithSpace");
+
+            Assert.IsNotNull(testSection);
+            Assert.IsNotNull(coll);
+            Assert.AreEqual(3, coll.Count);
+
+            Assert.IsNotNull(test1);
+            Assert.AreEqual("test", test1.Value);
+
+            Assert.IsNull(test2);
+            Assert.IsNull(test3);
+
+            Assert.IsNotNull(test4);
+            Assert.AreEqual("test", test4.Value);
+
+            Assert.IsNotNull(test5);
+            Assert.AreEqual("test", test5.Value);
+        }
+
+        [Test]
+        public void DeepMerger_MergeCollections_SubCollection_Merged() {
+            DeepMergerTestSection testSection = GetMergedConfig();
+
+            var coll = testSection?.SubCollection;
+            var test1Coll = coll?.FirstOrDefault(x => x.Name == "test1");
+            var test2Coll = coll?.FirstOrDefault(x => x.Name == "test2");
+            var test3Coll = coll?.FirstOrDefault(x => x.Name == "test3");
+
+            var test1T1 = test1Coll?.SubCollection?.FirstOrDefault(x => x.Name == "t1");
+            var test1T2 = test1Coll?.SubCollection?.FirstOrDefault(x => x.Name == "t2");
+            var test1T3 = test1Coll?.SubCollection?.FirstOrDefault(x => x.Name == "t3");
+            var test1T4 = test1Coll?.SubCollection?.FirstOrDefault(x => x.Name == "removed");
+
+            // The collections are all there
+            Assert.IsNotNull(testSection);
+            Assert.IsNotNull(coll);
+            Assert.IsNotNull(test1Coll);
+            Assert.IsNotNull(test2Coll);
+            Assert.IsNotNull(test3Coll);
+
+            Assert.IsNotNull(test1T1);
+            Assert.AreEqual("test", test1T1.Value);
+
+            Assert.IsNotNull(test1T2);
+            Assert.AreEqual("override", test1T2.Value);
+
+            Assert.IsNotNull(test1T3);
+            Assert.AreEqual("test", test1T3.Value);
+
+            Assert.IsNull(test1T4); // removed
+        }
+
+        [Test]
+        public void DeepMerger_MergeCollections_SubCollection_NoSideEffects() {
+            DeepMergerTestSection testSection = GetMergedConfig();
+
+            var coll = testSection?.SubCollection;
+            var test1Coll = coll?.FirstOrDefault(x => x.Name == "test1");
+            var test2Coll = coll?.FirstOrDefault(x => x.Name == "test2");
+            var test3Coll = coll?.FirstOrDefault(x => x.Name == "test3");
+
+            var test2T1 = test2Coll?.SubCollection?.FirstOrDefault(x => x.Name == "t1");
+            var test2T2 = test2Coll?.SubCollection?.FirstOrDefault(x => x.Name == "t2");
+            //var test2T3 = test2Coll?.SubCollection?.FirstOrDefault(x => x.Name == "t3");
+            var test2T4 = test2Coll?.SubCollection?.FirstOrDefault(x => x.Name == "removed");
+            
+
+            // The collections are all there
+            Assert.IsNotNull(testSection);
+            Assert.IsNotNull(coll);
+            Assert.IsNotNull(test1Coll);
+            Assert.IsNotNull(test2Coll);
+            Assert.IsNotNull(test3Coll);
+
+            Assert.IsNotNull(test2T1);
+            Assert.AreEqual("test2", test2T1.Value);
+
+            Assert.IsNull(test2T2);
+
+            Assert.IsNull(test2T4);
+        }
+
+        [Test]
+        public void DeepMerger_MergeCollections_SubCollection_Hopping() {
+            DeepMergerTestSection testSection = GetMergedConfig();
+
+            var coll = testSection?.SubCollection;
+            var test3Coll = coll?.FirstOrDefault(x => x.Name == "test3");
+
+            var test3T1 = test3Coll?.SubCollection?.FirstOrDefault(x => x.Name == "t1");
+
+            // The collections are all there
+            Assert.IsNotNull(testSection);
+            Assert.IsNotNull(coll);
+            Assert.IsNotNull(test3Coll);
+
+            Assert.IsNotNull(test3T1);
+            Assert.AreEqual("test4", test3T1.Value);
+        }
+    }
+
+    #region DeepMergerTestSection
+
+    public class DeepMergerTestSection : ConfigurationSection {
+        [ConfigurationProperty("ClearCollection", IsDefaultCollection = false)]
+        public TestElementCollectionElement ClearCollection => base["ClearCollection"] as TestElementCollectionElement;
+
+        [ConfigurationProperty("RemoveCollection", IsDefaultCollection = false)]
+        public TestElementCollectionElement RemoveCollection => base["RemoveCollection"] as TestElementCollectionElement;
+
+        [ConfigurationProperty("SubCollection", IsDefaultCollection = false)]
+        public TestCollectionElement SubCollection => base["SubCollection"] as TestCollectionElement;
+
+        #region MergedProperties
+        [ConfigurationProperty("OverriddenProperty", IsDefaultCollection = false)]
+        public StringElement OverriddenProperty => base["OverriddenProperty"] as StringElement;
+
+        [ConfigurationProperty("JumpOverProperty", IsDefaultCollection = false)]
+        public StringElement JumpOverProperty => base["JumpOverProperty"] as StringElement;
+
+        [ConfigurationProperty("NewEmptyProperty", IsDefaultCollection = false)]
+        public StringElement NewEmptyProperty => base["NewEmptyProperty"] as StringElement;
+
+        [ConfigurationProperty("NewNullProperty", IsDefaultCollection = false)]
+        public TestElement NewNullProperty => base["NewNullProperty"] as TestElement;
+        #endregion
+    }
+
+    public class StringElement : ConfigurationElement {
+        [ConfigurationProperty("value", IsRequired = true, IsKey = true)]
+        public string Value
+        {
+            get { return (string)this["value"]; }
+            set { this["value"] = value; }
+        }
+
+        public override string ToString() {
+            return Value ?? "null";
+        }
+    }
+
+    [ConfigurationCollection(typeof(TestElement), AddItemName = "ele",
+            CollectionType = ConfigurationElementCollectionType.BasicMap)]
+    public class TestElementCollectionElement : MergeableConfigurationCollection<TestElement> {
+    }
+
+    [ConfigurationCollection(typeof(SubElements), AddItemName = "main",
+            CollectionType = ConfigurationElementCollectionType.BasicMap)]
+    public class TestCollectionElement : MergeableConfigurationCollection<SubElements> {
+    }
+
+    public class SubElements : ConfigurationElement {
+
+        [ConfigurationProperty("name", IsRequired = false, IsKey = true)]
+        public string Name {
+            get { return (string)this["name"]; }
+            set { this["name"] = value; }
+        }
+
+        [ConfigurationProperty("values", IsRequired = false, IsKey = false)]
+        public TestSubCollectionElement SubCollection => base["values"] as TestSubCollectionElement;
+        
+        public HashSet<string> Subs => new HashSet<string>(SubCollection.Select(sub => sub.Value));
+
+        public override string ToString() {
+            var roles = string.Join("', '", Subs);
+            return $"User: {Name}, Values: ('{roles}'), " + base.ToString();
+        }
+    }
+
+
+
+    [ConfigurationCollection(typeof(TestElement), AddItemName = "sub",
+            CollectionType = ConfigurationElementCollectionType.BasicMap)]
+    public class TestSubCollectionElement : MergeableConfigurationCollection<TestElement> {
+
+    }
+
+
+    public class TestElement : ConfigurationElement {
+        [ConfigurationProperty("name", IsRequired = true, IsKey = true)]
+        public string Name {
+            get { return (string)this["name"]; }
+            set { this["name"] = value; }
+        }
+
+        [ConfigurationProperty("value", IsRequired = false, IsKey = false)]
+        public string Value {
+            get { return (string)this["value"]; }
+            set { this["value"] = value; }
+        }
+
+        public override string ToString() {
+            return $"{Name} :: {Value}";
+        }
+    }
+    #endregion
+}

--- a/NConfig.Tests/NConfig.Tests.csproj
+++ b/NConfig.Tests/NConfig.Tests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="ConfigurationRepositoryTests.cs" />
     <Compile Include="ConfigurationRepositoryWebTests.cs" />
     <Compile Include="MergeSection.cs" />
+    <Compile Include="DeepMergerTests.cs" />
     <Compile Include="PropertyLevelMergerTests.cs" />
     <Compile Include="TestSectionHandler.cs" />
     <Compile Include="TestSection.cs" />
@@ -85,6 +86,18 @@
     </None>
     <None Include="Configs\NConfigTest.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="DeepMergeConfigs\Test1.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="DeepMergeConfigs\Test2.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="DeepMergeConfigs\Test3.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="DeepMergeConfigs\Test4.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />
   </ItemGroup>

--- a/NConfig/IMergeableConfigurationCollection.cs
+++ b/NConfig/IMergeableConfigurationCollection.cs
@@ -7,25 +7,23 @@ namespace NConfig
     ///   Mergeable configuration collection (still untyped).
     ///   Is an IEnumerable(ConfigurationElement)
     /// </summary>
-    public interface IMergeableConfigurationCollection : IEnumerable {
+    public interface IMergeableConfigurationCollection : IEnumerable
+    {
         /// <summary>
         ///   Put the element into the collection (used by merger).
         /// </summary>
         /// <param name="element">The element to put into.</param>
         void Add(ConfigurationElement element);
-        //{ BaseAdd(element, false); }
 
         /// <summary>
         ///   Was this item removed &lt;remove6gt; in this configuration? (used by merger)
         /// </summary>
         bool IsRemoved(ConfigurationElement item);
-        //{ return BaseIsRemoved(GetElementKey(item)); }
 
         /// <summary>
         ///   Gets the element key of item (used by merge)
         /// </summary>
         object GetElementKeyForMerge(ConfigurationElement item);
-        //{ return GetElementKey(item); }
 
         /// <summary>
         ///   In this merge hierachy there was an clear tag, so that all lower hierachy members have to be ommitted.

--- a/NConfig/Implementation/Mergers/DeepMerger.cs
+++ b/NConfig/Implementation/Mergers/DeepMerger.cs
@@ -30,7 +30,7 @@
 
             var mergedSection = new TSection();
 
-            new DeepSectionMergerImpl().DoMerge(sections, mergedSection);
+            DeepSectionMergerImpl.DoMerge(sections, mergedSection);
 
             return mergedSection;
         }
@@ -57,7 +57,7 @@
             Type sectionType = sections.First().GetType();
             ConfigurationSection mergedSection = (ConfigurationSection) Activator.CreateInstance(sectionType);
 
-            new DeepSectionMergerImpl().DoMerge(sections, mergedSection);
+            DeepSectionMergerImpl.DoMerge(sections, mergedSection);
 
             return mergedSection;
         }
@@ -67,7 +67,7 @@
     /// <summary>
     ///   Used for implementing the generic and non-generic versions of the merger.
     /// </summary>
-    internal class DeepSectionMergerImpl
+    internal static class DeepSectionMergerImpl
     {
         /// <summary>
         ///   Fill in mergedSection as a merger of sections.
@@ -75,7 +75,7 @@
         /// </summary>
         /// <param name="mergedSection">Modified to be the merger</param>
         /// <param name="sections">The sections, in order, to be merged.</param>
-        internal void DoMerge(IEnumerable<ConfigurationSection> sections, ConfigurationSection mergedSection)
+        internal static void DoMerge(IEnumerable<ConfigurationSection> sections, ConfigurationSection mergedSection)
         {
             foreach (PropertyInformation resultProperty in mergedSection.ElementInformation.Properties)
             {
@@ -87,7 +87,7 @@
         }
 
 
-        private void UpdateProperty(List<PropertyInformation> sectionsProperties, PropertyInformation resultProperty)
+        private static void UpdateProperty(List<PropertyInformation> sectionsProperties, PropertyInformation resultProperty)
         {
             var resultType = GetInheritance(resultProperty);
 
@@ -129,7 +129,7 @@
             COLLECTION,
         }
 
-        private InheritanceTypes GetInheritance(PropertyInformation prop)
+        private static InheritanceTypes GetInheritance(PropertyInformation prop)
         {
 
             if (Inherits<ConfigurationElementCollection>(prop.Type))
@@ -147,7 +147,7 @@
             return InheritanceTypes.NONE;
         }
 
-        private void MergeRecursive(List<PropertyInformation> sectionsProperties, PropertyInformation resultProperty)
+        private static void MergeRecursive(List<PropertyInformation> sectionsProperties, PropertyInformation resultProperty)
         {
             var configElement = (ConfigurationElement) resultProperty.Value;
             foreach (PropertyInformation recursiveProperty in configElement.ElementInformation.Properties)
@@ -164,7 +164,7 @@
         /// <summary>
         ///   Merges one property's value. Regarding the hierachy level the first set value is used as result.
         /// </summary>
-        private void MergePropertyValue(List<PropertyInformation> sectionsProperties, PropertyInformation resultProperty)
+        private static void MergePropertyValue(List<PropertyInformation> sectionsProperties, PropertyInformation resultProperty)
         {
             foreach (PropertyInformation sectionProperty in sectionsProperties)
             {
@@ -194,7 +194,7 @@
         ///   b) for each element to add, build up a list of ones to be merged
         ///   c) for each list, merge and add to result
         /// </summary>
-        private void MergeCollection(IEnumerable<PropertyInformation> sectionsProperties,
+        private static void MergeCollection(IEnumerable<PropertyInformation> sectionsProperties,
             IMergeableConfigurationCollection resultElementColl)
         {
             var collectionInSections = CutAfterClear(GetMergeableCollections(sectionsProperties)).ToArray();
@@ -232,7 +232,7 @@
         /// <summary>
         ///   Merges the configs and does the recursion.
         /// </summary>
-        private ConfigurationElement MergeConfigurationElementList(IEnumerable<ConfigurationElement> configs)
+        private static ConfigurationElement MergeConfigurationElementList(IEnumerable<ConfigurationElement> configs)
         {
             //A possible problem may be that we are overriding an element of a different config. for unmerging this is probably wrong
             //However, NConfig does not require us to be able to unmerge...
@@ -268,7 +268,7 @@
         /// <summary>
         ///   Ommit all collections lower an clear tag.
         /// </summary>
-        private IEnumerable<IMergeableConfigurationCollection> CutAfterClear(
+        private static IEnumerable<IMergeableConfigurationCollection> CutAfterClear(
             IEnumerable<IMergeableConfigurationCollection> untypedCollections)
         {
             foreach (var coll in untypedCollections)

--- a/NConfig/Implementation/Mergers/DeepMerger.cs
+++ b/NConfig/Implementation/Mergers/DeepMerger.cs
@@ -1,0 +1,324 @@
+﻿namespace NConfig
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Configuration;
+    using System.Linq;
+
+
+    /// <summary>
+    /// Generic sections merger which performs deep configuration merge.
+    /// Important: Your collections need to implement <see cref="IMergeableConfigurationCollection"/>.
+    /// </summary>
+    /// <typeparam name="TSection">Configuration section type.</typeparam>
+    public class DeepMerger<TSection> : NSectionMerger<TSection>
+        where TSection : ConfigurationSection, new()
+    {
+
+        /// <summary>
+        /// Merges the specified typed configuration sections.
+        /// </summary>
+        /// <param name="sections">The sections to merge in order from the most important to lower.</param>
+        /// <returns>The merge resulting section.</returns>
+        public override TSection Merge(IEnumerable<TSection> sections)
+        {
+            if (sections == null || !sections.Any())
+            {
+                throw new ConfigurationErrorsException("No sections to merge");
+            }
+
+            var mergedSection = new TSection();
+
+            new DeepSectionMergerImpl().DoMerge(sections, mergedSection);
+
+            return mergedSection;
+        }
+    }
+
+    /// <summary>
+    /// Non-generic sections merger which performs deep configuration merge.
+    /// </summary>
+    public class DeepMerger : NSectionMerger
+    {
+
+        /// <summary>
+        /// Merges the specified typed configuration sections.
+        /// </summary>
+        /// <param name="sections">The sections to merge in order from the most important to lower.</param>
+        /// <returns>The merge resulting section.</returns>
+        public override ConfigurationSection Merge(IEnumerable<ConfigurationSection> sections)
+        {
+            if (sections == null || !sections.Any())
+            {
+                throw new ConfigurationErrorsException("No sections to merge");
+            }
+
+            Type sectionType = sections.First().GetType();
+            ConfigurationSection mergedSection = (ConfigurationSection) Activator.CreateInstance(sectionType);
+
+            new DeepSectionMergerImpl().DoMerge(sections, mergedSection);
+
+            return mergedSection;
+        }
+    }
+
+
+    /// <summary>
+    ///   Used for implementing the generic and non-generic versions of the merger.
+    /// </summary>
+    internal class DeepSectionMergerImpl
+    {
+        /// <summary>
+        ///   Fill in mergedSection as a merger of sections.
+        ///   Be carefull: in some circumstances one of sections may be modified.
+        /// </summary>
+        /// <param name="mergedSection">Modified to be the merger</param>
+        /// <param name="sections">The sections, in order, to be merged.</param>
+        internal void DoMerge(IEnumerable<ConfigurationSection> sections, ConfigurationSection mergedSection)
+        {
+            foreach (PropertyInformation resultProperty in mergedSection.ElementInformation.Properties)
+            {
+                var propertiesOfSections = sections
+                    .Select(section => section.ElementInformation.Properties[resultProperty.Name])
+                    .ToList();
+                UpdateProperty(propertiesOfSections, resultProperty);
+            }
+        }
+
+
+        private void UpdateProperty(List<PropertyInformation> sectionsProperties, PropertyInformation resultProperty)
+        {
+            var resultType = GetInheritance(resultProperty);
+
+            switch (resultType)
+            {
+
+                case InheritanceTypes.COLLECTION:
+
+                    if (!(resultProperty.Value is IMergeableConfigurationCollection))
+                    {
+                        throw new ConfigurationErrorsException(
+                            $"Collection to merge {resultProperty.Name} is not of type {nameof(IMergeableConfigurationCollection)}. Necessary for the merger.");
+                    }
+
+                    var resultElementColl = (IMergeableConfigurationCollection) resultProperty.Value;
+                    MergeCollection(sectionsProperties, resultElementColl);
+
+                    // attributes of the collection i.e. http://stackoverflow.com/questions/8829414/how-to-have-custom-attribute-in-configurationelementcollection
+                    MergeRecursive(sectionsProperties, resultProperty);
+
+                    break;
+
+                case InheritanceTypes.CONFIGURATION_ELEMENT:
+                    MergeRecursive(sectionsProperties, resultProperty);
+
+                    break;
+                default:
+                    // The order of sections should be from the most important to lower
+                    // copied from property - merger
+                    MergePropertyValue(sectionsProperties, resultProperty);
+                    break;
+            }
+        }
+
+        private enum InheritanceTypes
+        {
+            NONE,
+            CONFIGURATION_ELEMENT,
+            COLLECTION,
+        }
+
+        private InheritanceTypes GetInheritance(PropertyInformation prop)
+        {
+
+            if (Inherits<ConfigurationElementCollection>(prop.Type))
+            {
+                //For us all are the same:
+                // a) We do the sorting anyway, 
+                // b) Basic does not allow remove/clear anyway, so both properties will never occur
+                return InheritanceTypes.COLLECTION;
+            }
+
+            if (Inherits<ConfigurationElement>(prop.Type))
+            {
+                return InheritanceTypes.CONFIGURATION_ELEMENT;
+            }
+            return InheritanceTypes.NONE;
+        }
+
+        private void MergeRecursive(List<PropertyInformation> sectionsProperties, PropertyInformation resultProperty)
+        {
+            var configElement = (ConfigurationElement) resultProperty.Value;
+            foreach (PropertyInformation recursiveProperty in configElement.ElementInformation.Properties)
+            {
+                var propertiesOfSections = sectionsProperties
+                    .Select(
+                        prop =>
+                            ((ConfigurationElement) prop.Value).ElementInformation.Properties[recursiveProperty.Name])
+                    .ToList();
+                UpdateProperty(propertiesOfSections, recursiveProperty);
+            }
+        }
+
+        /// <summary>
+        ///   Merges one property's value. Regarding the hierachy level the first set value is used as result.
+        /// </summary>
+        private void MergePropertyValue(List<PropertyInformation> sectionsProperties, PropertyInformation resultProperty)
+        {
+            foreach (PropertyInformation sectionProperty in sectionsProperties)
+            {
+                if (sectionProperty == null)
+                {
+                    break;
+                }
+                var isDefinedHere = IsConfigurationPropertyDefined(sectionProperty);
+                resultProperty.Value = sectionProperty.Value;
+                if (isDefinedHere)
+                {
+                    // leave the value of first defined in config file property.
+                    return;
+                }
+            }
+        }
+
+        /// <summary>
+        ///   The sections are ordered from "highest" to "lowest".
+        ///   if there is an :add: it is added in the section.
+        ///   There may be a :remove: "higher" which can be caught by collection.IsRemoved()
+        ///   The elements of a key are merged until there is another remove (or clear).
+        ///   A :clear: is got by section.EmitClear and need to break the processing afterwards.
+        ///
+        ///   What to do
+        ///   a) Cast and cut after clear
+        ///   b) for each element to add, build up a list of ones to be merged
+        ///   c) for each list, merge and add to result
+        /// </summary>
+        private void MergeCollection(IEnumerable<PropertyInformation> sectionsProperties,
+            IMergeableConfigurationCollection resultElementColl)
+        {
+            var collectionInSections = CutAfterClear(GetMergeableCollections(sectionsProperties)).ToArray();
+
+            // key -> mergeList
+            var allElements = new ConcurrentDictionary<object, List<ConfigurationElement>>();
+
+            for (int i = 0; i < collectionInSections.Length; i++)
+            {
+                foreach (ConfigurationElement item in collectionInSections[i])
+                {
+
+                    if (IsRemoved(collectionInSections, item, i))
+                    {
+                        // there was a :remove: in higher order, so ignore this
+                        // ignores also "later" elements after an :remove:
+                        continue;
+                    }
+
+                    // Adds into list (or start a new one)
+                    var key = collectionInSections[i].GetElementKeyForMerge(item);
+                    var list = allElements.GetOrAdd(key, new List<ConfigurationElement>());
+                    list.Add(item);
+                }
+            }
+
+            // Do the merge
+            foreach (var configElementList in allElements.Values)
+            {
+                ConfigurationElement mergedItem = MergeConfigurationElementList(configElementList);
+                resultElementColl.Add(mergedItem);
+            }
+        }
+
+        /// <summary>
+        ///   Merges the configs and does the recursion.
+        /// </summary>
+        private ConfigurationElement MergeConfigurationElementList(IEnumerable<ConfigurationElement> configs)
+        {
+            //A possible problem may be that we are overriding an element of a different config. for unmerging this is probably wrong
+            //However, NConfig does not require us to be able to unmerge...
+            var item = configs.First();
+
+            foreach (PropertyInformation recursiveProperty in item.ElementInformation.Properties)
+            {
+                var propertiesOfSections = configs
+                    .Select(prop => (prop).ElementInformation.Properties[recursiveProperty.Name])
+                    .Where(prop => prop != null)
+                    .ToList();
+                UpdateProperty(propertiesOfSections, recursiveProperty);
+            }
+            return item;
+        }
+
+        /// <summary>
+        ///   Was the item removed in any "upper" hierachy level?
+        /// </summary>
+        private static bool IsRemoved(IMergeableConfigurationCollection[] collectionInSections,
+            ConfigurationElement item, int currentLevel)
+        {
+            for (int i = currentLevel - 1; i >= 0; i--)
+            {
+                if (collectionInSections[i].IsRemoved(item))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        ///   Ommit all collections lower an clear tag.
+        /// </summary>
+        private IEnumerable<IMergeableConfigurationCollection> CutAfterClear(
+            IEnumerable<IMergeableConfigurationCollection> untypedCollections)
+        {
+            foreach (var coll in untypedCollections)
+            {
+                yield return coll;
+                // After yield return as current has to be still used
+                if (coll.EmitClear)
+                {
+                    yield break;
+                }
+            }
+        }
+
+        /// <summary>
+        ///   From all hierachy gets the property value casted as IMergeableConfigurationCollection.
+        /// </summary>
+        private static IEnumerable<IMergeableConfigurationCollection> GetMergeableCollections(
+            IEnumerable<PropertyInformation> sectionsProperties)
+        {
+            return sectionsProperties
+                .Where(x => x != null)
+                .Select(sectionProperty => sectionProperty.Value)
+                .Cast<IMergeableConfigurationCollection>(); // throws on purpose, so the user knows the problem
+        }
+
+
+
+        /// <summary>
+        ///   Does type inherit from TBase?
+        /// </summary>
+        private static bool Inherits<TBase>(Type type) where TBase : class
+        {
+            Type cur = type;
+
+            while (cur != null)
+            {
+                if (cur == typeof(TBase))
+                {
+                    return true;
+                }
+
+                cur = cur.BaseType;
+            }
+
+            return false;
+        }
+
+        private static bool IsConfigurationPropertyDefined(PropertyInformation property)
+        {
+            return property.ValueOrigin == PropertyValueOrigin.SetHere;
+        }
+    }
+}

--- a/NConfig/Implementation/Mergers/IMergeableConfigurationCollection.cs
+++ b/NConfig/Implementation/Mergers/IMergeableConfigurationCollection.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Configuration;
+
+namespace NConfig
+{
+    /// <summary>
+    ///   Mergeable configuration collection (still untyped).
+    ///   Is an IEnumerable(ConfigurationElement)
+    /// </summary>
+    public interface IMergeableConfigurationCollection : IEnumerable {
+        /// <summary>
+        ///   Put the element into the collection (used by merger).
+        /// </summary>
+        /// <param name="element">The element to put into.</param>
+        void Add(ConfigurationElement element);
+        //{ BaseAdd(element, false); }
+
+        /// <summary>
+        ///   Was this item removed &lt;remove6gt; in this configuration? (used by merger)
+        /// </summary>
+        bool IsRemoved(ConfigurationElement item);
+        //{ return BaseIsRemoved(GetElementKey(item)); }
+
+        /// <summary>
+        ///   Gets the element key of item (used by merge)
+        /// </summary>
+        object GetElementKeyForMerge(ConfigurationElement item);
+        //{ return GetElementKey(item); }
+
+        /// <summary>
+        ///   In this merge hierachy there was an clear tag, so that all lower hierachy members have to be ommitted.
+        /// </summary>
+        bool EmitClear { get; }
+    }
+}

--- a/NConfig/MergeableConfigurationCollection.cs
+++ b/NConfig/MergeableConfigurationCollection.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+
+namespace NConfig
+{
+    /// <summary>
+    ///   ConfigurationCollection having typed indexer and enumerator.
+    /// </summary>
+    /// <typeparam name="T">Type of the configuration element having a key.</typeparam>
+    public abstract class MergeableConfigurationCollection<T> : ConfigurationElementCollection,
+        IMergeableConfigurationCollection, IEnumerable<T>
+        where T : ConfigurationElement, new()
+    {
+
+        /// <summary>
+        ///   As we know the type of the element, we can create it.
+        /// </summary>
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new T();
+        }
+
+        /// <summary>
+        ///   Access to the i-th element type-safe.
+        /// </summary>
+        public T this[int index]
+        {
+            get { return BaseGet(index) as T; }
+        }
+
+        /// <summary>
+        ///   Type-safe getter for the element with the key.
+        /// </summary>
+        public T GetElement(string key)
+        {
+            return BaseGet(key) as T;
+        }
+
+        /// <summary>
+        ///   Enumerates all elements of the collection. 
+        ///   Please note that the sort order is not defined.
+        /// </summary>
+        public new IEnumerator<T> GetEnumerator()
+        {
+            return (
+                from i in Enumerable.Range(0, Count)
+                select this[i]).GetEnumerator();
+        }
+
+        /// <summary>
+        /// if T simply returns the value, no duplicates will be added to collection
+        /// </summary>
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            var keyElements = element.ElementInformation.Properties
+                .Cast<PropertyInformation>()
+                .Where(x => x.IsKey)
+                .ToList();
+
+            if (!keyElements.Any())
+            {
+                // no property is set as IsKey
+                throw new ConfigurationErrorsException(
+                    string.Format("Element type {0} in collection {1} does not have IsKey property specified: {2}",
+                        element.GetType(), GetType(), element));
+            }
+
+            if (keyElements.Count == 1)
+            {
+                return keyElements.First().Value;
+            }
+
+            // For several IsKey = true properties: use an aggregated key so that they are compared together
+            return string.Join(":--:", keyElements.Select(x => x.Value.ToString()));
+        }
+
+        void IMergeableConfigurationCollection.Add(ConfigurationElement element)
+        {
+            BaseAdd(element, false);
+        }
+
+        bool IMergeableConfigurationCollection.IsRemoved(ConfigurationElement item)
+        {
+            return BaseIsRemoved(GetElementKey(item));
+        }
+
+        object IMergeableConfigurationCollection.GetElementKeyForMerge(ConfigurationElement item)
+        {
+            return GetElementKey(item);
+        }
+    }
+}

--- a/NConfig/NConfig.csproj
+++ b/NConfig/NConfig.csproj
@@ -39,6 +39,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Implementation\Mergers\DeepMerger.cs" />
+    <Compile Include="Implementation\Mergers\IMergeableConfigurationCollection.cs" />
     <Compile Include="Implementation\Mergers\PropertyLevelMerger.cs" />
     <Compile Include="INSystemConfigurator.cs" />
     <Compile Include="IConfigurationFactory.cs" />

--- a/NConfig/NConfig.csproj
+++ b/NConfig/NConfig.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Implementation\Mergers\DeepMerger.cs" />
-    <Compile Include="Implementation\Mergers\IMergeableConfigurationCollection.cs" />
+    <Compile Include="IMergeableConfigurationCollection.cs" />
     <Compile Include="Implementation\Mergers\PropertyLevelMerger.cs" />
     <Compile Include="INSystemConfigurator.cs" />
     <Compile Include="IConfigurationFactory.cs" />
@@ -57,6 +57,7 @@
     <Compile Include="Implementation\Mergers\AppSettingsMerger.cs" />
     <Compile Include="Implementation\Mergers\ConectionStringsMerger.cs" />
     <Compile Include="Implementation\Mergers\DefaultMerger.cs" />
+    <Compile Include="MergeableConfigurationCollection.cs" />
     <Compile Include="NSectionMerger.cs" />
     <Compile Include="Implementation\ConfigurationRepositoryWeb.cs" />
     <Compile Include="Util\ConfigurationExtension.cs" />

--- a/README.md
+++ b/README.md
@@ -50,6 +50,29 @@ For Microsoft Azure Websites you can set the *NCONFIG_ALIAS* as an App Setting t
 
 **NOTE:**<br/> You should set **Copy To Output Directory = Copy Always** for all your custom configuration files, otherwise they will not be copied to *Bin* folder and NConfig will not find them.
 
+#### Mergers
+
+If you are using your custom configuration sections [https://msdn.microsoft.com/en-us/library/2tw134k3.aspx (HowTo)], the default "merger" utilizes the first section it finds in the hierachy, discarding settings defined in more general ones.
+However, you can switch to your own merger type for each section seperately. You even can write your own mergers yourself!
+
+* AppSettingsMerger
+  Used for the <appSettings> section utilizing only <add> (you cannot remove a setting in higher config files) within all config files.
+
+* ConectionStringsMerger
+  Used for the <appSettings> section utilizing only <add> (you cannot remove a setting in higher config files) within all config files.
+  
+* DeepMerger
+  Goes down the hierachy and tries to merge attributes also within properties. Merges collections (which need to implmenent IMergeableConfigurationCollection) via their key utilizing also <clear> and <remove>.
+  
+* DefaultMerger
+  Uses the first occurance of the whole section in hierachy discarding anything in other config files.
+  
+* PropertyLevelMerger
+  Uses the first occurance of any property in hierachy; does not merge sub-properties or attributes.
+
+You can set the merger via `NConfigurator.RegisterSectionMerger(new DeepMerger<TestConfigSection>());`
+  
+
 #### Sample code from Samples\ConsoleTest:
 ```csharp
 	// Setup NConfigurator to use Custom.config file from Config subfolder.
@@ -94,7 +117,7 @@ Use `log4net.Config` setting in appSettings:
 Or use `[assembly: log4net.Config.XmlConfigurator(ConfigFile = @"Config\separate-log4net.config")]` attribute. <br/>
 Or specify configuration file programmatically
 	
-```csahrp	    
+```csharp	    
         var fullPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"\Config\separate-log4net.config");
         log4net.Config.XmlConfigurator.Configure(new FileInfo(fullPath));
 ```
@@ -216,7 +239,7 @@ for all your configuration files.
 
 If you encounter any issues please do not hesitate to contact me directly or by raising issue on GitHub.
 
-## Windows Activation Service (WAS)
+#### Windows Activation Service (WAS)
 The above global.asax does not work for non-HTTP protocols such as net.tcp and net.pipe that is supported by the Windows Activation Service (WAS) on Windows Vista. There is no protocol-agnostic counterpart for HttpApplication in this case.
 
 Fortunately, ASP.NET provides a simple hook that works in a protocol agnostic way. The hook is based on the following AppInitialize method:
@@ -224,7 +247,21 @@ Fortunately, ASP.NET provides a simple hook that works in a protocol agnostic wa
 This method can be put in any type that is defined in a C# file in the application’s \App_Code directory. When the AppDomain is started, ASP.NET checks whether there is a type that has such as method (exact name and signature) and invokes it. Note that the AppInitialize method can be only defined once and it has to be in a code file instead of a pre-compiled assembly.
 More details [here] (http://blogs.msdn.com/b/wenlong/archive/2006/01/11/511514.aspx)
 
+### FAQ
+
+#### Section in config is ignored / Config file is ignored
+
+There are several reasons, why a config file or section seemingly is "ignored".
+
+* Is the section handler defined at the top of the config file?
+  ` <configSections><section name="testConfigSection" type="Custom.Config.TestConfigSection, TestConfig" /></configSections>`
+  
+* Did you set up the merger correctly?
+  `NConfigurator.RegisterSectionMerger(new DeepMerger<TestConfigSection>());`
+
 
 ### Thanks
 I would like to thank my colleagues for helping me testing and fixing this tool. Also thanks to TLK for his help in this file creation.
 Also I would like to thank the guys at 31337 chat for their support.
+
+The DeepMerger is a contribution by World Direct eBusiness Software GmbH.

--- a/Samples/DeepMergerSample/App.config
+++ b/Samples/DeepMergerSample/App.config
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<configuration>
+
+  <connectionStrings>
+    <add name="AppConfigDefined" connectionString="ConnectionString from App.Config"/>
+  </connectionStrings>
+
+  <appSettings>
+    <add key="AppConfigSettings" value="App Settings from App.Config."/>
+  </appSettings>    
+
+</configuration>

--- a/Samples/DeepMergerSample/Config/Any.Custom.config
+++ b/Samples/DeepMergerSample/Config/Any.Custom.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="TestConfigSection" type="DeepMergerSample.TestConfigSection, DeepMergerSample"/>
+  </configSections>
+
+  <TestConfigSection>
+    <MainProperty Attribute="Main property in Any.Custom.config">
+      <Collection>
+        <addOrSo Key="Element1" Attribute="Element 1 Any.Custom.Config" />
+        <remove Key="Element2" />
+      </Collection>
+    </MainProperty>
+  </TestConfigSection>
+</configuration>

--- a/Samples/DeepMergerSample/Config/Custom.config
+++ b/Samples/DeepMergerSample/Config/Custom.config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="TestConfigSection" type="DeepMergerSample.TestConfigSection, DeepMergerSample"/>
+  </configSections>
+
+  <TestConfigSection>
+    <MainProperty Attribute="Main property in Custom.config">
+      <Collection>
+        <addOrSo Key="Element1" Attribute="Element 1 Custom Config" />
+        <addOrSo Key="Element2" Attribute="Element 2 Custom Config" />
+        <addOrSo Key="Element3" Attribute="Element 3 Custom Config" />
+      </Collection>
+    </MainProperty>
+  </TestConfigSection>
+
+</configuration>

--- a/Samples/DeepMergerSample/Config/Personal.Custom.config
+++ b/Samples/DeepMergerSample/Config/Personal.Custom.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="TestConfigSection" type="DeepMergerSample.TestConfigSection, DeepMergerSample"/>
+  </configSections>
+
+  <TestConfigSection>
+    <MainProperty Attribute="Main property in Personal.Custom.config">
+      <Collection>
+        <clear />
+        <addOrSo Key="Element1" Attribute="Element 1 Personal.Custom.Config" />
+      </Collection>
+    </MainProperty>
+  </TestConfigSection>
+
+</configuration>

--- a/Samples/DeepMergerSample/DeepMergerSample.csproj
+++ b/Samples/DeepMergerSample/DeepMergerSample.csproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4D229D37-CEC4-40E2-A066-535B96733F36}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DeepMergerSample</RootNamespace>
+    <AssemblyName>DeepMergerSample</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="TestConfigSection.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="Config\Any.Custom.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Config\Personal.Custom.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Config\Custom.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="HostMap.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\NConfig\NConfig.csproj">
+      <Project>{0DE97382-565B-4083-AE6E-C3EA3B1AB83D}</Project>
+      <Name>NConfig</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Samples/DeepMergerSample/DeepMergerSample.sln
+++ b/Samples/DeepMergerSample/DeepMergerSample.sln
@@ -1,0 +1,42 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeepMergerSample", "DeepMergerSample.csproj", "{4D229D37-CEC4-40E2-A066-535B96733F36}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NConfig", "..\..\NConfig\NConfig.csproj", "{0DE97382-565B-4083-AE6E-C3EA3B1AB83D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4D229D37-CEC4-40E2-A066-535B96733F36}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{4D229D37-CEC4-40E2-A066-535B96733F36}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{4D229D37-CEC4-40E2-A066-535B96733F36}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{4D229D37-CEC4-40E2-A066-535B96733F36}.Debug|x86.ActiveCfg = Debug|x86
+		{4D229D37-CEC4-40E2-A066-535B96733F36}.Debug|x86.Build.0 = Debug|x86
+		{4D229D37-CEC4-40E2-A066-535B96733F36}.Release|Any CPU.ActiveCfg = Release|x86
+		{4D229D37-CEC4-40E2-A066-535B96733F36}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{4D229D37-CEC4-40E2-A066-535B96733F36}.Release|Mixed Platforms.Build.0 = Release|x86
+		{4D229D37-CEC4-40E2-A066-535B96733F36}.Release|x86.ActiveCfg = Release|x86
+		{4D229D37-CEC4-40E2-A066-535B96733F36}.Release|x86.Build.0 = Release|x86
+		{0DE97382-565B-4083-AE6E-C3EA3B1AB83D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0DE97382-565B-4083-AE6E-C3EA3B1AB83D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0DE97382-565B-4083-AE6E-C3EA3B1AB83D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{0DE97382-565B-4083-AE6E-C3EA3B1AB83D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{0DE97382-565B-4083-AE6E-C3EA3B1AB83D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0DE97382-565B-4083-AE6E-C3EA3B1AB83D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0DE97382-565B-4083-AE6E-C3EA3B1AB83D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0DE97382-565B-4083-AE6E-C3EA3B1AB83D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{0DE97382-565B-4083-AE6E-C3EA3B1AB83D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{0DE97382-565B-4083-AE6E-C3EA3B1AB83D}.Release|x86.ActiveCfg = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Samples/DeepMergerSample/HostMap.config
+++ b/Samples/DeepMergerSample/HostMap.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <configSections>
+        <section name="hostMap" type="NConfig.HostMapSection, NConfig"/>
+    </configSections>
+
+    <hostMap>
+      <add host="wrk09" alias="Personal"/>
+      <add host="*" alias="Any"/>
+    </hostMap>
+   
+</configuration>

--- a/Samples/DeepMergerSample/Program.cs
+++ b/Samples/DeepMergerSample/Program.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using NConfig;
+using System.Configuration;
+
+namespace DeepMergerSample
+{
+    class Program
+    {
+        static void Main()
+        {
+            Console.WriteLine("DeepMerger NConfig Sample. \r\n");
+
+            // Registering the correct merger for my section
+            NConfigurator.RegisterSectionMerger(new DeepMerger<TestConfigSection>());
+
+            // Setup NConfigurator to use Custom.config file from Config subfolder.
+            NConfigurator.UsingFile(@"Config\Custom.config").SetAsSystemDefault();
+
+            var testSection = NConfigurator.Default.GetSection<TestConfigSection>();
+            
+
+            Console.WriteLine("Property Attribute: {0} \r\n".F(testSection.TestValue.Attribute));
+
+            Console.WriteLine("");
+            Console.WriteLine("MERGED COLLECTION: ");
+            foreach(var key in testSection.TestValue.Collection)
+            {
+                Console.WriteLine(key.Key + " : " + key.Attribute);
+            }
+
+            Console.ReadKey();
+        }
+    }
+
+    static class StringExtensions
+    {
+        public static string F(this string format, params object[] args)
+        {
+            return string.Format(format, args);
+        }
+    }
+
+}

--- a/Samples/DeepMergerSample/Properties/AssemblyInfo.cs
+++ b/Samples/DeepMergerSample/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DeepMergerSample")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DeepMergerSample")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("91288f65-64fa-49bb-9126-75b129049174")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Samples/DeepMergerSample/TestConfigSection.cs
+++ b/Samples/DeepMergerSample/TestConfigSection.cs
@@ -1,0 +1,50 @@
+﻿using System.Configuration;
+using NConfig;
+
+namespace DeepMergerSample
+{
+    public class TestConfigSection : ConfigurationSection
+    {
+        [ConfigurationProperty("MainProperty")]
+        public FirstLayerElement TestValue {
+            get {
+                return (FirstLayerElement)this["MainProperty"];
+            }
+           
+        }
+    }
+
+    public class FirstLayerElement : ConfigurationElement
+    {
+        [ConfigurationProperty("Attribute")]
+        public string Attribute {
+            get {
+                return (string)this["Attribute"];
+            }
+        }
+
+        [ConfigurationProperty("Collection")]
+        public TestCollection Collection { get { return (TestCollection) this["Collection"]; } }
+    }
+
+    [ConfigurationCollection(typeof(SecondLayerElement), AddItemName = "addOrSo",
+            CollectionType = ConfigurationElementCollectionType.BasicMap)]
+    public class TestCollection : MergeableConfigurationCollection<SecondLayerElement> { }
+
+
+    public class SecondLayerElement : ConfigurationElement
+    {
+        [ConfigurationProperty("Key", IsKey = true)]
+        public string Key
+        {
+            get { return (string)this["Key"]; }
+        }
+
+        
+        [ConfigurationProperty("Attribute")]
+        public string Attribute
+        {
+            get { return (string) this["Attribute"]; }
+        }
+        }
+}


### PR DESCRIPTION
Added the deep merger implemented for our projects.
Added IMergeableConfigurationCollection interface supporting the DeepMerger

The merger uses the first occurance on attribute level.
Collections are merged via add/remove/clear where several adds with the same key are merged on attribute level.