### PR TITLE
VS 2017 and nuget.config schema

### DIFF
--- a/NConfig.Tests/NConfig.Tests.csproj
+++ b/NConfig.Tests/NConfig.Tests.csproj
@@ -107,6 +107,9 @@
       <Name>NConfig</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/NConfig.Tests/packages.config
+++ b/NConfig.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.5.10.11092" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net40" />
   <package id="RhinoMocks" version="3.6" />
 </packages>

--- a/nuget.config
+++ b/nuget.config
@@ -1,3 +1,5 @@
-<settings>
-	<repositoryPath>Lib</repositoryPath>
-</settings>
+<configuration>
+	<config>
+		<repositoryPath>Lib</repositoryPath>
+	</config>
+</configuration>


### PR DESCRIPTION
1. VS 2017 needs NUnit TestAdapter. It still builds with VS 2015.

2. nuget.config does have a `<settings>` tag but instead `<configuration>`.