### PR TITLE
NullReferenceException fixed in GetProperty method

### DIFF
--- a/NConfig/Implementation/System/ReflectionAccessor.cs
+++ b/NConfig/Implementation/System/ReflectionAccessor.cs
@@ -144,7 +144,9 @@ namespace NConfig
         private Func<object,object> PropertyGetterFunc(string name)
         {
             PropertyInfo pi = AccessedType.GetProperty(name, accessFlags);
-            var getter = pi?.GetGetMethod(true);
+            if (pi == null)
+                return null;
+            var getter = pi.GetGetMethod(true);
             if (getter != null)
                 return o => getter.Invoke(o, null);
             return null;
@@ -153,7 +155,9 @@ namespace NConfig
         private Action<object, object> PropertySetterAction(string name)
         {
             PropertyInfo pi = AccessedType.GetProperty(name, accessFlags);
-            var setter = pi?.GetSetMethod(true);
+            if (pi == null)
+                return null;
+            var setter = pi.GetSetMethod(true);
             if (setter != null)
                 return (i, v) => setter.Invoke(i, new[] {v});
             return null;

--- a/NConfig/Implementation/System/ReflectionAccessor.cs
+++ b/NConfig/Implementation/System/ReflectionAccessor.cs
@@ -144,7 +144,7 @@ namespace NConfig
         private Func<object,object> PropertyGetterFunc(string name)
         {
             PropertyInfo pi = AccessedType.GetProperty(name, accessFlags);
-            var getter = pi.GetGetMethod(true);
+            var getter = pi?.GetGetMethod(true);
             if (getter != null)
                 return o => getter.Invoke(o, null);
             return null;
@@ -153,7 +153,7 @@ namespace NConfig
         private Action<object, object> PropertySetterAction(string name)
         {
             PropertyInfo pi = AccessedType.GetProperty(name, accessFlags);
-            var setter = pi.GetSetMethod(true);
+            var setter = pi?.GetSetMethod(true);
             if (setter != null)
                 return (i, v) => setter.Invoke(i, new[] {v});
             return null;


### PR DESCRIPTION
After windows update KB4040973 NConfig started crashing with exception:

[NullReferenceException: Object reference not set to an instance of an object.]
   NConfig.ReflectionAccessor.PropertyGetterFunc(String name) in c:\Projects\ThirdParty\NConfig\NConfig\Implementation\System\ReflectionAccessor.cs:147
   NConfig.<>c__DisplayClass4`2.<Memoize>b__3(TArg a) in c:\Projects\ThirdParty\NConfig\NConfig\Util\MemoizeExtensions.cs:40
   NConfig.ReflectionAccessor.GetProperty(String name) in c:\Projects\ThirdParty\NConfig\NConfig\Implementation\System\ReflectionAccessor.cs:65
   NConfig.NWebSystemConfigurator.SubstituteSystemConfiguration(IConfigurationFactory factory, IList`1 fileNames) in c:\Projects\ThirdParty\NConfig\NConfig\Implementation\System\Web\NWebSystemConfigurator.cs:40
   NConfig.INConfigurationExtensions.SetAsSystemDefault(INConfiguration config) in c:\Projects\ThirdParty\NConfig\NConfig\INConfiguration.cs:139
   Invoicing.Improve.SL.GUI.Web.Global.Application_Start(Object sender, EventArgs e) in C:\prj\Inv\src\Invoicing.Improve.SL.GUI.Web\Global.asax.cs:11 